### PR TITLE
feat: adding the ability to transfer cmdline over dbus

### DIFF
--- a/src/gpupdate.c
+++ b/src/gpupdate.c
@@ -70,7 +70,7 @@ get_gpo_exe(void)
 	return gpo_exe ? gpo_exe : "/usr/sbin/gpoa";
 }
 
-static int apply_gpo(const char *user, int flags)
+static int apply_gpo(const char *user, int flags, char* loglevel)
 {
 	int status;
 	pid_t pid = fork();
@@ -80,9 +80,9 @@ static int apply_gpo(const char *user, int flags)
 		return 1;
 	case 0:
 	if (flags & FLAG_FORCE) {
-		execl(exe, exe, "--force", user, NULL);
+		execl(exe, exe, "--force", "--loglevel", loglevel, user, NULL);
 	} else {
-		execl(exe, exe, user, NULL);
+		execl(exe, exe, "--loglevel", loglevel, user, NULL);
 	}
 		return 3;
 	default:
@@ -143,7 +143,7 @@ gpupdate(const char *user, int flags, char* loglevel)
 				return HANDLER_INVALID_INVOCATION;
 			}
 		}
-		ret = apply_gpo(user, flags);
+		ret = apply_gpo(user, flags, loglevel);
 		if (ret != 0) {
 			syslog(LOG_ERR,
 			       "error applying GPO for %s (error code %d)", log_user, ret);

--- a/src/gpupdate.c
+++ b/src/gpupdate.c
@@ -50,7 +50,7 @@
 
 #define _(_x) _x
 static const char *exe;
-static const char *gpo_exe;
+static char *gpo_exe;
 static struct passwd *pwd;
 
 #define FLAG_STDIN	(1 << 1)

--- a/src/gpupdate.c
+++ b/src/gpupdate.c
@@ -55,6 +55,7 @@ static struct passwd *pwd;
 
 #define FLAG_QUIET	(1 << 1)
 #define FLAG_FORCE	(1 << 2)
+#define FLAG_STDIN	(1 << 3)
 
 /*
  * get_gpo_dir
@@ -148,6 +149,68 @@ gpupdate(const char *user, int flags)
 			return HANDLER_FAILURE;
 		}
 	}
+	return 0;
+}
+
+int
+getFlags(int argc, char** argv, char** gpo_exe, char** loglevel, int *flags)
+{
+	if (argc == 0)
+	{
+		return 0;
+	}
+	if (!argv || !gpo_exe || !gpo_exe || !loglevel || !flags)
+	{
+		return -1;
+	}
+
+	if (*gpo_exe)
+	{
+		free(*gpo_exe);
+	}
+	(*gpo_exe) = strdup("/usr/sbin/gpoa");
+	if (*loglevel)
+	{
+		free(*loglevel);
+	}
+	(*loglevel) = strdup("4");
+
+	int ret;
+	while ((ret = getopt(argc, argv, "ifl:p:")) != -1)
+	{
+		switch (ret){
+			case 'f':
+				(*flags) |= FLAG_FORCE;
+				break;
+			case 'p':
+				if (*gpo_exe)
+				{
+					free(*gpo_exe);
+				}
+				(*gpo_exe) = strdup(optarg);
+				break;
+			case 'i': {
+				(*flags) |= FLAG_STDIN;
+				break;
+			}
+			case 'l':
+				if (*loglevel)
+				{
+					free(*loglevel);
+				}
+				(*loglevel) = strdup(optarg);
+				break;
+		default:
+			fprintf(stderr, "Valid options:\n"
+				"-q\tDo not print messages when applying "
+				"a policy.\n"
+				"-f\tForce GPT download.\n"
+				"-p PATH\tOverride the gpo applier "
+				"binary (\"%s\").\n", *gpo_exe);
+			return -1;
+		}
+	}
+
 	return 0;
 }
 

--- a/src/gpupdate.c
+++ b/src/gpupdate.c
@@ -94,11 +94,12 @@ static int apply_gpo(const char *user, int flags)
 
 /* Apply group policies via GPO applier. */
 static int
-gpupdate(const char *user, int flags)
+gpupdate(const char *user, int flags, char* loglevel)
 {
 	int ret;
 	struct stat st;
 	const char *log_user = user;
+	int i_loglevel = atoi(loglevel);
 
 	/* Now make sure that the user or computer
 	   a) no user (computer)
@@ -128,7 +129,7 @@ gpupdate(const char *user, int flags)
 	exe = get_gpo_exe();
 	if (exe != NULL) {
 		/* Set the text of the result message. */
-		if (!(flags & FLAG_QUIET)) {
+		if (!(i_loglevel < 4)) {
 			printf(_("Apply group policies for %s."), log_user);
 		}
 		syslog(LOG_NOTICE, "Apply group policies for %s.", log_user);
@@ -309,11 +310,11 @@ main(int argc, char **argv)
 
 			return ret;
 		}
-		ret = gpupdate(user, flags);
+		ret = gpupdate(user, flags, loglevel);
 	}
 	else
 	{
-		ret = gpupdate(NULL, flags);
+		ret = gpupdate(NULL, flags, loglevel);
 	}
 
 	free(loglevel);

--- a/src/gpupdate.c
+++ b/src/gpupdate.c
@@ -53,9 +53,8 @@ static const char *exe;
 static const char *gpo_exe;
 static struct passwd *pwd;
 
-#define FLAG_QUIET	(1 << 1)
+#define FLAG_STDIN	(1 << 1)
 #define FLAG_FORCE	(1 << 2)
-#define FLAG_STDIN	(1 << 3)
 
 /*
  * get_gpo_dir

--- a/src/oddjobd-gpupdate.conf.in
+++ b/src/oddjobd-gpupdate.conf.in
@@ -25,20 +25,20 @@
       <interface name="@NAMESPACE@.oddjob_gpupdate">
 
         <method name="gpupdate_computer">
-          <helper exec="@mypkglibexecdir@/gpupdate"
-                  arguments="0"/>
+          <helper exec="@mypkglibexecdir@/gpupdate -i"
+                  arguments="1"/>
           <allow/>
         </method>
 
         <method name="gpupdate">
-          <helper exec="@mypkglibexecdir@/gpupdate"
-                  arguments="0"
+          <helper exec="@mypkglibexecdir@/gpupdate -i"
+                  arguments="1"
                   prepend_user_name="yes"/>
           <allow/>
         </method>
 
         <method name="gpupdatefor">
-          <helper exec="@mypkglibexecdir@/gpupdate"
+          <helper exec="@mypkglibexecdir@/gpupdate -i"
                   arguments="1"/>
           <allow user="root"/>
         </method>

--- a/src/util.c
+++ b/src/util.c
@@ -37,6 +37,35 @@
 #include <string.h>
 #include <unistd.h>
 
+/* Generate argv and argc from argument string (a_str)  */
+char** make_argv(char* a_str, size_t* argc_out, const char a_delim)
+{
+	if (!argc_out)
+	{
+		return NULL;
+	}
+
+	char delim[2] = {a_delim, 0};
+	char** result = NULL;
+	char* token = strtok(a_str, delim);
+
+	(*argc_out) = 0;
+
+	// getopt skip first argument........
+	result = reallocarray(result, ++(*argc_out), sizeof(char*));
+	result[0] = NULL;
+
+	while(token)
+	{
+		result = reallocarray(result, ++(*argc_out), sizeof(char*));
+		result[(*argc_out) - 1] = strdup(token);
+		token = strtok(NULL, delim);
+	}
+
+	return result;
+}
+
+
 /* Write to a file, handling transient errors. */
 ssize_t
 retry_write(int fd, unsigned char *buf, size_t length)

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,7 @@
 #ifndef oddjob_util_h
 #define oddjob_util_h
 
+char** make_argv(char* a_str, size_t* argc_out, const char a_delim);
 ssize_t retry_write(int fd, unsigned char *buf, size_t length);
 void *oddjob_malloc(size_t size);
 void *oddjob_malloc0(size_t size);


### PR DESCRIPTION
Adding the ability to transfer cmdline over dbus with next introspection:
```xml
<!-- ... -->
<method name="gpupdate_computer_arg">
      <arg direction="in" type="s"/>
      <arg direction="out" name="exit_status" type="i"/>
      <arg direction="out" name="stdout" type="s"/>
      <arg direction="out" name="stderr" type="s"/>
</method>
<method name="gpupdate_arg">
      <arg direction="in" type="s"/>
      <arg direction="out" name="exit_status" type="i"/>
      <arg direction="out" name="stdout" type="s"/>
      <arg direction="out" name="stderr" type="s"/>
</method>
<!-- ... -->
```
where the one and only `in` argument is a string, which is a cmdline.
At this moment, only 2 supported arguments: `-l <NUM>` as loglevel(default 4), and `-f` as force.